### PR TITLE
Allow to populate basemodels by name

### DIFF
--- a/cowdao_cowpy/cow/swap.py
+++ b/cowdao_cowpy/cow/swap.py
@@ -43,12 +43,10 @@ async def swap_tokens(
     chain_id = SupportedChainId(chain.value[0])
     order_book_api = OrderBookApi(OrderBookAPIConfigFactory.get_config(env, chain_id))
 
-    order_quote_request = OrderQuoteRequest.model_validate(
-        {
-            "sellToken": sell_token,
-            "buyToken": buy_token,
-            "from": account._address,
-        }
+    order_quote_request = OrderQuoteRequest(
+        sellToken=sell_token,
+        buyToken=buy_token,
+        from_=account._address,  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
     )
     order_side = OrderQuoteSide1(
         kind=OrderQuoteSideKindSell.sell,
@@ -99,21 +97,19 @@ async def post_order(
     signature: EcdsaSignature,
     order_book_api: OrderBookApi,
 ) -> UID:
-    order_creation = OrderCreation.model_validate(
-        {
-            "from": account.address,
-            "sellToken": order.sellToken,
-            "buyToken": order.buyToken,
-            "sellAmount": str(order.sellAmount),
-            "feeAmount": str(order.feeAmount),
-            "buyAmount": str(order.buyAmount),
-            "validTo": order.validTo,
-            "kind": order.kind,
-            "partiallyFillable": order.partiallyFillable,
-            "appData": order.appData,
-            "signature": signature.data,
-            "signingScheme": "eip712",
-            "receiver": order.receiver,
-        }
+    order_creation = OrderCreation(
+        from_=account.address,  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
+        sellToken=order.sellToken,
+        buyToken=order.buyToken,
+        sellAmount=str(order.sellAmount),
+        feeAmount=str(order.feeAmount),
+        buyAmount=str(order.buyAmount),
+        validTo=order.validTo,
+        kind=order.kind,
+        partiallyFillable=order.partiallyFillable,
+        appData=order.appData,
+        signature=signature.data,
+        signingScheme="eip712",
+        receiver=order.receiver,
     )
     return await order_book_api.post_order(order_creation)

--- a/cowdao_cowpy/order_book/generated/model.py
+++ b/cowdao_cowpy/order_book/generated/model.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, RootModel, confloat
+from pydantic import BaseModel, Field, RootModel, confloat, ConfigDict
 
 
 class TransactionHash(RootModel[str]):
@@ -572,6 +572,8 @@ class OrderQuoteSide(
 
 
 class OrderQuoteRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     sellToken: Address = Field(..., description="ERC-20 token to be sold")
     buyToken: Address = Field(..., description="ERC-20 token to be bought")
     receiver: Optional[Address] = Field(
@@ -598,6 +600,8 @@ class OrderQuoteRequest(BaseModel):
 
 
 class OrderQuoteResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     quote: OrderParameters
     from_: Optional[Address] = Field(None, alias="from")
     expiration: str = Field(
@@ -636,6 +640,8 @@ class SolverCompetitionResponse(BaseModel):
 
 
 class OrderCreation(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     sellToken: Address = Field(..., description="see `OrderParameters::sellToken`")
     buyToken: Address = Field(..., description="see `OrderParameters::buyToken`")
     receiver: Optional[Address] = Field(

--- a/cowdao_cowpy/order_book/generated/model.py
+++ b/cowdao_cowpy/order_book/generated/model.py
@@ -577,15 +577,15 @@ class OrderQuoteRequest(BaseModel):
     sellToken: Address = Field(..., description="ERC-20 token to be sold")
     buyToken: Address = Field(..., description="ERC-20 token to be bought")
     receiver: Optional[Address] = Field(
-        None,
+        default=None,
         description="An optional address to receive the proceeds of the trade instead of the\n`owner` (i.e. the order signer).\n",
     )
     appData: Optional[Union[AppData, AppDataHash]] = Field(
-        None,
+        default=None,
         description="AppData which will be assigned to the order.\nExpects either a string JSON doc as defined on [AppData](https://github.com/cowprotocol/app-data) or a\nhex encoded string for backwards compatibility.\nWhen the first format is used, it's possible to provide the derived appDataHash field.\n",
     )
     appDataHash: Optional[AppDataHash] = Field(
-        None,
+        default=None,
         description="The hash of the stringified JSON appData doc.\nIf present, `appData` field must be set with the aforementioned data where this hash is derived from.\nIn case they differ, the call will fail.\n",
     )
     sellTokenBalance: Optional[SellTokenSource] = "erc20"
@@ -594,7 +594,7 @@ class OrderQuoteRequest(BaseModel):
     priceQuality: Optional[PriceQuality] = "verified"
     signingScheme: Optional[SigningScheme] = "eip712"
     onchainOrder: Optional[Any] = Field(
-        False,
+        default=False,
         description='Flag to signal whether the order is intended for on-chain order placement. Only valid\nfor non ECDSA-signed orders."\n',
     )
 
@@ -645,7 +645,7 @@ class OrderCreation(BaseModel):
     sellToken: Address = Field(..., description="see `OrderParameters::sellToken`")
     buyToken: Address = Field(..., description="see `OrderParameters::buyToken`")
     receiver: Optional[Address] = Field(
-        None, description="see `OrderParameters::receiver`"
+        default=None, description="see `OrderParameters::receiver`"
     )
     sellAmount: TokenAmount = Field(
         ..., description="see `OrderParameters::sellAmount`"
@@ -666,12 +666,12 @@ class OrderCreation(BaseModel):
     signingScheme: SigningScheme
     signature: Signature
     from_: Optional[Address] = Field(
-        None,
+        default=None,
         alias="from",
         description="If set, the backend enforces that this address matches what is decoded as the *signer* of\nthe signature. This helps catch errors with invalid signature encodings as the backend\nmight otherwise silently work with an unexpected address that for example does not have\nany balance.\n",
     )
     quoteId: Optional[int] = Field(
-        None,
+        default=None,
         description="Orders can optionally include a quote ID. This way the order can be linked to a quote\nand enable providing more metadata when analysing order slippage.\n",
     )
     appData: Union[AppData, AppDataHash] = Field(
@@ -679,7 +679,7 @@ class OrderCreation(BaseModel):
         description="This field comes in two forms for backward compatibility. The hash form will eventually \nstop being accepted.\n",
     )
     appDataHash: Optional[AppDataHash] = Field(
-        None,
+        default=None,
         description="May be set for debugging purposes. If set, this field is compared to what the backend\ninternally calculates as the app data hash based on the contents of `appData`. If the\nhash does not match, an error is returned. If this field is set, then `appData` **MUST** be\na string encoding of a JSON object.\n",
     )
 

--- a/cowdao_cowpy/order_book/generated/model.py
+++ b/cowdao_cowpy/order_book/generated/model.py
@@ -658,10 +658,10 @@ class OrderCreation(BaseModel):
         ..., description="see `OrderParameters::partiallyFillable`"
     )
     sellTokenBalance: Optional[SellTokenSource] = Field(
-        "erc20", description="see `OrderParameters::sellTokenBalance`"
+        default="erc20", description="see `OrderParameters::sellTokenBalance`"
     )
     buyTokenBalance: Optional[BuyTokenDestination] = Field(
-        "erc20", description="see `OrderParameters::buyTokenBalance`"
+        default="erc20", description="see `OrderParameters::buyTokenBalance`"
     )
     signingScheme: SigningScheme
     signature: Signature

--- a/poetry.lock
+++ b/poetry.lock
@@ -1025,13 +1025,13 @@ idna = ">=2.0.0"
 
 [[package]]
 name = "eth-abi"
-version = "5.1.0"
+version = "5.2.0"
 description = "eth_abi: Python utilities for working with Ethereum ABI definitions, especially encoding and decoding"
 optional = false
 python-versions = "<4,>=3.8"
 files = [
-    {file = "eth_abi-5.1.0-py3-none-any.whl", hash = "sha256:84cac2626a7db8b7d9ebe62b0fdca676ab1014cc7f777189e3c0cd721a4c16d8"},
-    {file = "eth_abi-5.1.0.tar.gz", hash = "sha256:33ddd756206e90f7ddff1330cc8cac4aa411a824fe779314a0a52abea2c8fc14"},
+    {file = "eth_abi-5.2.0-py3-none-any.whl", hash = "sha256:17abe47560ad753f18054f5b3089fcb588f3e3a092136a416b6c1502cb7e8877"},
+    {file = "eth_abi-5.2.0.tar.gz", hash = "sha256:178703fa98c07d8eecd5ae569e7e8d159e493ebb6eeb534a8fe973fbc4e40ef0"},
 ]
 
 [package.dependencies]
@@ -1040,10 +1040,10 @@ eth-utils = ">=2.0.0"
 parsimonious = ">=0.10.0,<0.11.0"
 
 [package.extras]
-dev = ["build (>=0.9.0)", "bumpversion (>=0.5.3)", "eth-hash[pycryptodome]", "hypothesis (>=4.18.2,<5.0.0)", "ipython", "pre-commit (>=3.4.0)", "pytest (>=7.0.0)", "pytest-pythonpath (>=0.7.1)", "pytest-timeout (>=2.0.0)", "pytest-xdist (>=2.4.0)", "sphinx (>=6.0.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)", "tox (>=4.0.0)", "twine", "wheel"]
-docs = ["sphinx (>=6.0.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)"]
-test = ["eth-hash[pycryptodome]", "hypothesis (>=4.18.2,<5.0.0)", "pytest (>=7.0.0)", "pytest-pythonpath (>=0.7.1)", "pytest-timeout (>=2.0.0)", "pytest-xdist (>=2.4.0)"]
-tools = ["hypothesis (>=4.18.2,<5.0.0)"]
+dev = ["build (>=0.9.0)", "bump_my_version (>=0.19.0)", "eth-hash[pycryptodome]", "hypothesis (>=6.22.0,<6.108.7)", "ipython", "mypy (==1.10.0)", "pre-commit (>=3.4.0)", "pytest (>=7.0.0)", "pytest-pythonpath (>=0.7.1)", "pytest-timeout (>=2.0.0)", "pytest-xdist (>=2.4.0)", "sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx_rtd_theme (>=1.0.0)", "towncrier (>=24,<25)", "tox (>=4.0.0)", "twine", "wheel"]
+docs = ["sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx_rtd_theme (>=1.0.0)", "towncrier (>=24,<25)"]
+test = ["eth-hash[pycryptodome]", "hypothesis (>=6.22.0,<6.108.7)", "pytest (>=7.0.0)", "pytest-pythonpath (>=0.7.1)", "pytest-timeout (>=2.0.0)", "pytest-xdist (>=2.4.0)"]
+tools = ["hypothesis (>=6.22.0,<6.108.7)"]
 
 [[package]]
 name = "eth-account"
@@ -1093,13 +1093,13 @@ test = ["hypothesis (>=3.31.2)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
 
 [[package]]
 name = "eth-hash"
-version = "0.7.0"
+version = "0.7.1"
 description = "eth-hash: The Ethereum hashing function, keccak256, sometimes (erroneously) called sha3"
 optional = false
-python-versions = ">=3.8, <4"
+python-versions = "<4,>=3.8"
 files = [
-    {file = "eth-hash-0.7.0.tar.gz", hash = "sha256:bacdc705bfd85dadd055ecd35fd1b4f846b671add101427e089a4ca2e8db310a"},
-    {file = "eth_hash-0.7.0-py3-none-any.whl", hash = "sha256:b8d5a230a2b251f4a291e3164a23a14057c4a6de4b0aa4a16fa4dc9161b57e2f"},
+    {file = "eth_hash-0.7.1-py3-none-any.whl", hash = "sha256:0fb1add2adf99ef28883fd6228eb447ef519ea72933535ad1a0b28c6f65f868a"},
+    {file = "eth_hash-0.7.1.tar.gz", hash = "sha256:d2411a403a0b0a62e8247b4117932d900ffb4c8c64b15f92620547ca5ce46be5"},
 ]
 
 [package.dependencies]
@@ -1107,8 +1107,8 @@ pycryptodome = {version = ">=3.6.6,<4", optional = true, markers = "extra == \"p
 safe-pysha3 = {version = ">=1.0.0", optional = true, markers = "python_version >= \"3.9\" and extra == \"pysha3\""}
 
 [package.extras]
-dev = ["build (>=0.9.0)", "bumpversion (>=0.5.3)", "ipython", "pre-commit (>=3.4.0)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)", "sphinx (>=6.0.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)", "tox (>=4.0.0)", "twine", "wheel"]
-docs = ["sphinx (>=6.0.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)"]
+dev = ["build (>=0.9.0)", "bump_my_version (>=0.19.0)", "ipython", "mypy (==1.10.0)", "pre-commit (>=3.4.0)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)", "sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx_rtd_theme (>=1.0.0)", "towncrier (>=24,<25)", "tox (>=4.0.0)", "twine", "wheel"]
+docs = ["sphinx (>=6.0.0)", "sphinx-autobuild (>=2021.3.14)", "sphinx_rtd_theme (>=1.0.0)", "towncrier (>=24,<25)"]
 pycryptodome = ["pycryptodome (>=3.6.6,<4)"]
 pysha3 = ["pysha3 (>=1.0.0,<2.0.0)", "safe-pysha3 (>=1.0.0)"]
 test = ["pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
@@ -1136,13 +1136,13 @@ test = ["pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
 
 [[package]]
 name = "eth-keys"
-version = "0.6.0"
+version = "0.6.1"
 description = "eth-keys: Common API for Ethereum key operations"
 optional = false
 python-versions = "<4,>=3.8"
 files = [
-    {file = "eth_keys-0.6.0-py3-none-any.whl", hash = "sha256:b396fdfe048a5bba3ef3990739aec64901eb99901c03921caa774be668b1db6e"},
-    {file = "eth_keys-0.6.0.tar.gz", hash = "sha256:ba33230f851d02c894e83989185b21d76152c49b37e35b61b1d8a6d9f1d20430"},
+    {file = "eth_keys-0.6.1-py3-none-any.whl", hash = "sha256:7deae4cd56e862e099ec58b78176232b931c4ea5ecded2f50c7b1ccbc10c24cf"},
+    {file = "eth_keys-0.6.1.tar.gz", hash = "sha256:a43e263cbcabfd62fa769168efc6c27b1f5603040e4de22bb84d12567e4fd962"},
 ]
 
 [package.dependencies]
@@ -1151,8 +1151,8 @@ eth-utils = ">=2"
 
 [package.extras]
 coincurve = ["coincurve (>=12.0.0)"]
-dev = ["asn1tools (>=0.146.2)", "build (>=0.9.0)", "bumpversion (>=0.5.3)", "coincurve (>=12.0.0)", "eth-hash[pysha3]", "factory-boy (>=3.0.1)", "hypothesis (>=5.10.3)", "ipython", "pre-commit (>=3.4.0)", "pyasn1 (>=0.4.5)", "pytest (>=7.0.0)", "towncrier (>=21,<22)", "tox (>=4.0.0)", "twine", "wheel"]
-docs = ["towncrier (>=21,<22)"]
+dev = ["asn1tools (>=0.146.2)", "build (>=0.9.0)", "bump_my_version (>=0.19.0)", "coincurve (>=12.0.0)", "eth-hash[pysha3]", "factory-boy (>=3.0.1)", "hypothesis (>=5.10.3)", "ipython", "mypy (==1.10.0)", "pre-commit (>=3.4.0)", "pyasn1 (>=0.4.5)", "pytest (>=7.0.0)", "towncrier (>=24,<25)", "tox (>=4.0.0)", "twine", "wheel"]
+docs = ["towncrier (>=24,<25)"]
 test = ["asn1tools (>=0.146.2)", "eth-hash[pysha3]", "factory-boy (>=3.0.1)", "hypothesis (>=5.10.3)", "pyasn1 (>=0.4.5)", "pytest (>=7.0.0)"]
 
 [[package]]
@@ -2673,13 +2673,13 @@ files = [
 
 [[package]]
 name = "pyright"
-version = "1.1.391"
+version = "1.1.392.post0"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.391-py3-none-any.whl", hash = "sha256:54fa186f8b3e8a55a44ebfa842636635688670c6896dcf6cf4a7fc75062f4d15"},
-    {file = "pyright-1.1.391.tar.gz", hash = "sha256:66b2d42cdf5c3cbab05f2f4b76e8bec8aa78e679bfa0b6ad7b923d9e027cadb2"},
+    {file = "pyright-1.1.392.post0-py3-none-any.whl", hash = "sha256:252f84458a46fa2f0fd4e2f91fc74f50b9ca52c757062e93f6c250c0d8329eb2"},
+    {file = "pyright-1.1.392.post0.tar.gz", hash = "sha256:3b7f88de74a28dcfa90c7d90c782b6569a48c2be5f9d4add38472bdaac247ebd"},
 ]
 
 [package.dependencies]
@@ -3467,13 +3467,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.28.1"
+version = "20.29.0"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb"},
-    {file = "virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329"},
+    {file = "virtualenv-20.29.0-py3-none-any.whl", hash = "sha256:c12311863497992dc4b8644f8ea82d3b35bb7ef8ee82e6630d76d0197c39baf9"},
+    {file = "virtualenv-20.29.0.tar.gz", hash = "sha256:6345e1ff19d4b1296954cee076baaf58ff2a12a84a338c62b02eda39f20aa982"},
 ]
 
 [package.dependencies]
@@ -3710,4 +3710,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "449552983871c69993de2c999565f5e00c5fd90553b6b9bdc4ef34d7009ecac5"
+content-hash = "de2fba3588dc631cb38027ff65550219455a51378b03d4b81458813262dccca3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ multiformats = "^0.3.1.post4"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.3.7"
-pyright = "^1.1.358"
+pyright = "^1.1.392"
 pytest = "^8.1.1"
 ipython = "^8.23.0"
 pre-commit = "^3.7.0"

--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -26,18 +26,16 @@ def ceil_div(p, q):
 ORDER_KIND_SELL = "SELL"
 
 SAMPLE_ORDER = Order(
-    **{
-        "sell_token": fill_bytes(20, 0x01),
-        "buy_token": fill_bytes(20, 0x02),
-        "receiver": fill_bytes(20, 0x03),
-        "sell_amount": to_wei("42", "ether"),
-        "buy_amount": to_wei("13.37", "ether"),
-        "valid_to": 0xFFFFFFFF,
-        "app_data": keccak(text="")[0:20],
-        "fee_amount": to_wei("1.0", "ether"),
-        "kind": ORDER_KIND_SELL,
-        "partially_fillable": False,
-    }
+    sell_token=fill_bytes(20, 0x01),
+    buy_token=fill_bytes(20, 0x02),
+    receiver=fill_bytes(20, 0x03),
+    sell_amount=to_wei("42", "ether"),
+    buy_amount=to_wei("13.37", "ether"),
+    valid_to=0xFFFFFFFF,
+    app_data=str(keccak(text="")[0:20]),
+    fee_amount=to_wei("1.0", "ether"),
+    kind=ORDER_KIND_SELL,
+    partially_fillable=False,
 )
 
 SAMPLE_DOMAIN = TypedDataDomain(

--- a/tests/e2e/test_post_and_cancel_order_live_e2e.py
+++ b/tests/e2e/test_post_and_cancel_order_live_e2e.py
@@ -57,13 +57,11 @@ async def test_post_and_cancel_order_live_e2e():
     )
 
     mock_order_quote_request = OrderQuoteRequest(
-        **{
-            "sellToken": WXDAI_GNOSIS_MAINNET_ADDRESS,
-            "buyToken": COW_TOKEN_GNOSIS_MAINNET_ADDRESS,
-            "receiver": E2E_GNOSIS_MAINNET_TESTING_EOA_ADDRESS,
-            "from": E2E_GNOSIS_MAINNET_TESTING_EOA_ADDRESS,
-            "onchainOrder": False,
-        }
+        sellToken=WXDAI_GNOSIS_MAINNET_ADDRESS,
+        buyToken=COW_TOKEN_GNOSIS_MAINNET_ADDRESS,
+        receiver=E2E_GNOSIS_MAINNET_TESTING_EOA_ADDRESS,
+        from_=E2E_GNOSIS_MAINNET_TESTING_EOA_ADDRESS,  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
+        onchainOrder=False,
     )
 
     mock_order_quote_side = OrderQuoteSide1(

--- a/tests/e2e/test_post_and_cancel_order_live_e2e.py
+++ b/tests/e2e/test_post_and_cancel_order_live_e2e.py
@@ -76,20 +76,18 @@ async def test_post_and_cancel_order_live_e2e():
     )
 
     order = Order(
-        **{
-            "sell_token": WXDAI_GNOSIS_MAINNET_ADDRESS,
-            "buy_token": COW_TOKEN_GNOSIS_MAINNET_ADDRESS,
-            "receiver": E2E_GNOSIS_MAINNET_TESTING_EOA_ADDRESS,
-            "sell_amount": (10**15).__str__(),
-            "buy_amount": (10**20).__str__(),
-            "valid_to": quote.quote.validTo,
-            "fee_amount": "0",
-            "kind": "sell",
-            "partially_fillable": False,
-            "sell_token_balance": "erc20",
-            "buy_token_balance": "erc20",
-            "app_data": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        }
+        sell_token=WXDAI_GNOSIS_MAINNET_ADDRESS,
+        buy_token=COW_TOKEN_GNOSIS_MAINNET_ADDRESS,
+        receiver=str(E2E_GNOSIS_MAINNET_TESTING_EOA_ADDRESS),
+        sell_amount=10**15,
+        buy_amount=10**20,
+        valid_to=quote.quote.validTo,
+        fee_amount=0,
+        kind="sell",
+        partially_fillable=False,
+        sell_token_balance="erc20",
+        buy_token_balance="erc20",
+        app_data="0x0000000000000000000000000000000000000000000000000000000000000000",
     )
 
     order_domain = domain(

--- a/tests/order_book/test_api.py
+++ b/tests/order_book/test_api.py
@@ -65,17 +65,15 @@ async def test_get_trades_by_order_uid(order_book_api):
 @pytest.mark.asyncio
 async def test_post_quote(order_book_api):
     mock_order_quote_request = OrderQuoteRequest(
-        **{
-            "sellToken": "0x",
-            "buyToken": "0x",
-            "receiver": "0x",
-            "appData": "app_data_object",
-            "appDataHash": "0x",
-            "from": "0x",
-            "priceQuality": "verified",
-            "signingScheme": "eip712",
-            "onchainOrder": False,
-        }
+        sellToken="0x",
+        buyToken="0x",
+        receiver="0x",
+        appData="app_data_object",
+        appDataHash="0x",
+        from_="0x",  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
+        priceQuality="verified",
+        signingScheme="eip712",
+        onchainOrder=False,
     )
 
     mock_order_quote_side = OrderQuoteSide1(
@@ -118,25 +116,23 @@ async def test_post_quote(order_book_api):
 async def test_post_order(order_book_api):
     mock_uid = "mock_uid"
     mock_order_creation = OrderCreation(
-        **{
-            "sellToken": "0x",
-            "buyToken": "0x",
-            "sellAmount": "0",
-            "buyAmount": "0",
-            "validTo": 0,
-            "feeAmount": "0",
-            "kind": "buy",
-            "partiallyFillable": True,
-            "appData": "0x",
-            "signingScheme": "eip712",
-            "signature": "0x",
-            "receiver": "0x",
-            "sellTokenBalance": "erc20",
-            "buyTokenBalance": "erc20",
-            "quoteId": 0,
-            "appDataHash": "0x",
-            "from": "0x",
-        }
+        sellToken="0x",
+        buyToken="0x",
+        sellAmount="0",
+        buyAmount="0",
+        validTo=0,
+        feeAmount="0",
+        kind="buy",
+        partiallyFillable=True,
+        appData="0x",
+        signingScheme="eip712",
+        signature="0x",
+        receiver="0x",
+        sellTokenBalance="erc20",
+        buyTokenBalance="erc20",
+        quoteId=0,
+        appDataHash="0x",
+        from_="0x",  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
     )
     with patch("httpx.AsyncClient.request", new_callable=AsyncMock) as mock_request:
         mock_request.return_value.text = mock_uid


### PR DESCRIPTION
With the current behavior, we need to initialise these models like this:

```
order_quote_request = OrderQuoteRequest.model_validate(
        {
            "sellToken": sell_token,
            "buyToken": buy_token,
            "from": account._address,
        }
    )
```

because `from` is a reserved keyword in Python, so `OrderQuoteRequest(from=...)` is invalid syntax.

The problem is that if we initialise Pydantic model from dictionary, we are losing typing benefits.

Ie we can do 

```
order_quote_request = OrderQuoteRequest.model_validate(
        {
            "blah1": sell_token,
            "blah2": buy_token,
            "bla3": account._address,
        }
    )
```

and type checker won't complain.

After this change, we are able to do:

```
order_quote_request = OrderQuoteRequest(
            sellToken=sell_token,
            buyToken=buy_token,
            from_=account._address,
)
```

and then it's type safe (type checker will complain if we try to pass in bad field name, bad type, etc.)