### PR TITLE
Add Missing Routes

### DIFF
--- a/cowdao_cowpy/order_book/api.py
+++ b/cowdao_cowpy/order_book/api.py
@@ -1,12 +1,14 @@
 from typing import Any, Dict, List, Union
 from cowdao_cowpy.common.api.api_base import ApiBase, Context
-from cowdao_cowpy.common.config import SupportedChainId
+from cowdao_cowpy.common.api.errors import UnexpectedResponseError
+from cowdao_cowpy.common.config import SupportedChainId, ENVS_LIST
 from cowdao_cowpy.order_book.config import OrderBookAPIConfigFactory
 from cowdao_cowpy.order_book.generated.model import (
     UID,
     Address,
     AppDataHash,
     AppDataObject,
+    CompetitionOrderStatus,
     NativePriceResponse,
     Order,
     OrderCreation,
@@ -80,6 +82,23 @@ class OrderBookApi(ApiBase):
             path=f"/api/v1/orders/{order_uid}",
             context_override=context_override,
             response_model=Order,
+        )
+
+    async def get_order_multi_env(self, order_uid: UID, context_override: Context = {}) -> Order:
+        for env in ENVS_LIST:
+            # TODO extract & exclude current env from loop.
+            try:
+                # TODO: context override does not appear to work as expected.
+                result = await self.get_order_by_uid(order_uid, {**context_override, "env": env.value})
+                return result
+            except UnexpectedResponseError:
+                pass
+
+    async def get_order_competition_status(self, order_uid: UID, context_override: Context = {}) -> CompetitionOrderStatus:
+        return await self._fetch(
+            path=f"/api/v1/orders/{order_uid}/status",
+            context_override=context_override,
+            response_model=CompetitionOrderStatus,
         )
 
     def get_order_link(self, order_uid: UID) -> str:

--- a/tests/e2e/test_post_and_cancel_order_live_e2e.py
+++ b/tests/e2e/test_post_and_cancel_order_live_e2e.py
@@ -31,7 +31,7 @@ from cowdao_cowpy.order_book.generated.model import (
     OrderQuoteSide1,
     OrderQuoteSideKindSell,
     SigningScheme as ModelSigningScheme,
-    TokenAmount,
+    TokenAmount, UID,
 )
 
 
@@ -124,3 +124,13 @@ async def test_post_and_cancel_order_live_e2e():
     )
 
     assert cancellation_result == "Cancelled"
+
+@pytest.mark.asyncio
+async def test_get_order_multi_env():
+    config = OrderBookAPIConfigFactory.get_config(
+        "prod", SupportedChainId.MAINNET
+    )
+    order_book = OrderBookApi(config)
+    staging_order_id: UID = "0xa130262be8ef33fa9ba9e5a9a2dd416be2eaf28fc2727bb4e0e8ea4d8ac5b3798d99f8b2710e6a3b94d9bf465a98e5273069acbd6197b574"
+    result = await order_book.get_order_multi_env(staging_order_id)
+    assert result is not None


### PR DESCRIPTION
This PR attempts to add two missing routes. 

1. Get Order Status (shouldn't be a problem)
2. Get Order MultiEnv

Unfortunately, get order multi-env demonstrates an issue with usability of "context override". 

Observe the [test order](https://explorer.cow.fi/orders/0xa130262be8ef33fa9ba9e5a9a2dd416be2eaf28fc2727bb4e0e8ea4d8ac5b3798d99f8b2710e6a3b94d9bf465a98e5273069acbd6197b574) was posted in the staging environment, but the Orderbook API in the test is configured with production. The function is meant to get the order regardless of environment configuration and ideally would make use of the "context_override" (cf [cow-sdk](https://github.com/cowprotocol/cow-sdk/blob/d27c205af6b0b45872a8ac3d898f2c4b15499bcb/src/order-book/api.ts#L251)). 

However, it does not appear that environment can be overridden this way.