### PR TITLE
Safe support in swap_tokens

### DIFF
--- a/cowdao_cowpy/cow/swap.py
+++ b/cowdao_cowpy/cow/swap.py
@@ -3,7 +3,13 @@ from cowdao_cowpy.common.config import SupportedChainId
 from cowdao_cowpy.common.constants import CowContractAddress
 from cowdao_cowpy.contracts.domain import domain
 from cowdao_cowpy.contracts.order import Order
-from cowdao_cowpy.contracts.sign import EcdsaSignature, SigningScheme
+from cowdao_cowpy.contracts.sign import (
+    EcdsaSignature,
+    SigningScheme,
+    PreSignSignature,
+    Signature,
+)
+from cowdao_cowpy.common.constants import ZERO_APP_DATA
 from cowdao_cowpy.contracts.sign import sign_order as _sign_order
 from cowdao_cowpy.order_book.api import OrderBookApi
 from cowdao_cowpy.order_book.config import Envs, OrderBookAPIConfigFactory
@@ -34,6 +40,7 @@ async def swap_tokens(
     chain: Chain,
     sell_token: ChecksumAddress,
     buy_token: ChecksumAddress,
+    safe_address: ChecksumAddress | None = None,
     app_data: str = ZERO_APP_DATA,
     env: Envs = "prod",
     slippage_tolerance: float = 0.005,
@@ -47,7 +54,7 @@ async def swap_tokens(
     order_quote_request = OrderQuoteRequest(
         sellToken=sell_token,
         buyToken=buy_token,
-        from_=account._address,  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
+        from_=safe_address if safe_address is not None else account._address,  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
     )
     order_side = OrderQuoteSide1(
         kind=OrderQuoteSideKindSell.sell,
@@ -58,7 +65,7 @@ async def swap_tokens(
     order = Order(
         sell_token=sell_token,
         buy_token=buy_token,
-        receiver=account.address,
+        receiver=safe_address if safe_address is not None else account.address,
         valid_to=order_quote.quote.validTo,
         app_data=app_data,
         sell_amount=str(
@@ -73,8 +80,17 @@ async def swap_tokens(
         buy_token_balance="erc20",
     )
 
-    signature = sign_order(chain, account, order)
-    order_uid = await post_order(account, order, signature, order_book_api)
+    signature = (
+        PreSignSignature(
+            scheme=SigningScheme.PRESIGN,
+            data=safe_address,
+        )
+        if safe_address is not None
+        else sign_order(chain, account, order)
+    )
+    order_uid = await post_order(
+        account, safe_address, order, signature, order_book_api
+    )
     order_link = order_book_api.get_order_link(order_uid)
 
     return CompletedOrder(uid=order_uid, url=order_link)
@@ -98,12 +114,13 @@ def sign_order(chain: Chain, account: LocalAccount, order: Order) -> EcdsaSignat
 
 async def post_order(
     account: LocalAccount,
+    safe_address: ChecksumAddress | None,
     order: Order,
-    signature: EcdsaSignature,
+    signature: Signature,
     order_book_api: OrderBookApi,
 ) -> UID:
     order_creation = OrderCreation(
-        from_=account.address,  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
+        from_=safe_address if safe_address is not None else account.address,  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
         sellToken=order.sellToken,
         buyToken=order.buyToken,
         sellAmount=str(order.sellAmount),
@@ -114,7 +131,7 @@ async def post_order(
         partiallyFillable=order.partiallyFillable,
         appData=order.appData,
         signature=signature.data,
-        signingScheme="eip712",
+        signingScheme=signature.scheme.name.lower(),
         receiver=order.receiver,
     )
     return await order_book_api.post_order(order_creation)

--- a/cowdao_cowpy/cow/swap.py
+++ b/cowdao_cowpy/cow/swap.py
@@ -26,7 +26,6 @@ from cowdao_cowpy.order_book.generated.model import (
 from eth_account.signers.local import LocalAccount
 from pydantic import BaseModel
 from eth_typing.evm import ChecksumAddress
-from cowdao_cowpy.common.constants import ZERO_APP_DATA
 
 
 class CompletedOrder(BaseModel):

--- a/cowdao_cowpy/order_book/api.py
+++ b/cowdao_cowpy/order_book/api.py
@@ -77,7 +77,7 @@ class OrderBookApi(ApiBase):
         self, order_uid: UID, context_override: Context = {}
     ) -> Order:
         return await self._fetch(
-            path=f"/api/v1/orders/{order_uid}",
+            path=f"/api/v1/orders/{order_uid.root}",
             context_override=context_override,
             response_model=Order,
         )

--- a/cowdao_cowpy/order_book/generated/model.py
+++ b/cowdao_cowpy/order_book/generated/model.py
@@ -436,6 +436,10 @@ class OrderMetaData(BaseModel):
     class_: OrderClass = Field(..., alias="class")
     owner: Address
     uid: UID
+    settlementContract: Optional[Address] = Field(
+        None,
+        description="The address of the settlement contract that will be used to settle the order.\n",
+    )
     availableBalance: Optional[TokenAmount] = Field(
         None,
         description="Unused field that is currently always set to `null` and will be removed in the future.\n",


### PR DESCRIPTION
This add ability to use `swap_tokens` from Safe, but Safe library isn't included, so people have to execute one required step by themselves.

The flow is as (using tooling from our [PMAT](https://github.com/gnosis/prediction-market-agent-tooling) library, but that't not a requirement ofc):

```python
    # wxDai
    sell_token = Web3.to_checksum_address("0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d")
    # GNO
    buy_token = Web3.to_checksum_address("0x9c58bacc331c9aa871afd802db6379a98e80cedb")

    # 1. Step: Approve the CowContractAddress.VAULT_RELAYER to spend the sell token.
    ContractERC20OnGnosisChain(address=sell_token).approve(
        keys,
        Web3.to_checksum_address(CowContractAddress.VAULT_RELAYER.value),
        amount_wei=one,
    )

    # 2. Step: Post the swap token order. If SAFE_ADDRESS isn't None, it will be of pre-signed type.
    order = await swap_tokens(
        amount=one,
        account=account,
        chain=Chain.GNOSIS,
        sell_token=sell_token,
        buy_token=buy_token,
        safe_address=keys.SAFE_ADDRESS,
    )
    posted_order = await order_book_api.get_order_by_uid(order.uid)

    # 3. Step: Sign it by the owner of the Safe and wait.
    CowGPv2SettlementContract(
        address=Web3.to_checksum_address(posted_order.settlementContract.root)
    ).setPreSignature(
        keys,
        HexBytes(posted_order.uid.root),
        True,
    )
```