### PR TITLE
chore: automatically append version to utm

### DIFF
--- a/cowdao_cowpy/__init__.py
+++ b/cowdao_cowpy/__init__.py
@@ -1,3 +1,10 @@
+import importlib.metadata
+
+try:
+    __version__ = importlib.metadata.version("cowdao-cowpy")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "development"
+
 from cowdao_cowpy.cow.swap import swap_tokens
 
-__all__ = ["swap_tokens"]
+__all__ = ["swap_tokens", "__version__"]

--- a/cowdao_cowpy/app_data/utils.py
+++ b/cowdao_cowpy/app_data/utils.py
@@ -10,6 +10,7 @@ from dataclasses import asdict, dataclass
 import json
 
 from cowdao_cowpy.app_data.consts import DEFAULT_IPFS_READ_URI
+from cowdao_cowpy import __version__
 
 # CID uses multibase to self-describe the encoding used (See https://github.com/multiformats/multibase)
 #   - Most reference implementations (multiformats/cid or Pinata, etc) use base58btc encoding
@@ -79,7 +80,7 @@ def generate_app_data(
             },
             "utm": {
                 "utmSource": "cowmunity",
-                "utmMedium": "cow-py",
+                "utmMedium": f"cow-py@{__version__}",
                 "utmCampaign": "developer-cohort",
                 "utmContent": "🥩📢🌀🐮 'MÖØ'",
                 "utmTerm": "python"


### PR DESCRIPTION
This PR:

1. Automatically retrieves the package version information and supplements the UTM medium to convey version information for additional statistics.