### PR TITLE
fix: eliminate PydanticSerializationUnexpectedValue warnings for enum defaults

### DIFF
--- a/cowdao_cowpy/order_book/base.py
+++ b/cowdao_cowpy/order_book/base.py
@@ -2,4 +2,4 @@ from pydantic import BaseModel as PyDanticBaseModel
 
 
 class BaseModel(PyDanticBaseModel):
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "validate_default": True}

--- a/tests/order_book/test_serialization_warnings.py
+++ b/tests/order_book/test_serialization_warnings.py
@@ -1,0 +1,71 @@
+# test_serialization_warnings.py
+import json
+import warnings
+
+from cowdao_cowpy.order_book.generated.model import (
+    BuyTokenDestination,
+    OrderCreation,
+    OrderQuoteRequest,
+    PriceQuality,
+    SellTokenSource,
+    SigningScheme,
+)
+
+
+def _dump_without_user_warnings(model):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        dumped = model.model_dump_json(by_alias=True)
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert (
+        user_warnings == []
+    ), f"unexpected UserWarnings: {[str(w.message) for w in user_warnings]}"
+    return json.loads(dumped)
+
+
+def test_order_quote_request_defaults_serialize_without_warnings():
+    order_quote_request = OrderQuoteRequest(
+        sellToken="0x6810e776880c02933d47db1b9fc05908e5386b96",
+        buyToken="0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+        from_="0xfb3c7eb936caa12b5a884d612393969a557d4307",  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
+        appData="0x0000000000000000000000000000000000000000000000000000000000000000",
+    )
+
+    data = _dump_without_user_warnings(order_quote_request)
+
+    assert data["sellTokenBalance"] == "erc20"
+    assert data["buyTokenBalance"] == "erc20"
+    assert data["priceQuality"] == "verified"
+    assert data["signingScheme"] == "eip712"
+
+    assert order_quote_request.sellTokenBalance is SellTokenSource.erc20
+    assert order_quote_request.buyTokenBalance is BuyTokenDestination.erc20
+    assert order_quote_request.priceQuality is PriceQuality.verified
+    assert order_quote_request.signingScheme is SigningScheme.eip712
+
+
+def test_order_creation_defaults_serialize_without_warnings():
+    # The omitted defaulted fields are exactly what this test exercises.
+    order_creation = OrderCreation(  # type: ignore[reportCallIssue]
+        sellToken="0x6810e776880c02933d47db1b9fc05908e5386b96",
+        buyToken="0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+        sellAmount="1",
+        buyAmount="1",
+        validTo=0,
+        feeAmount="0",
+        kind="sell",
+        partiallyFillable=False,
+        appData="0x0000000000000000000000000000000000000000000000000000000000000000",
+        signingScheme="eip712",
+        signature="0x",
+    )
+
+    data = _dump_without_user_warnings(order_creation)
+
+    assert data["sellTokenBalance"] == "erc20"
+    assert data["buyTokenBalance"] == "erc20"
+    assert data["signingScheme"] == "eip712"
+
+    assert order_creation.sellTokenBalance is SellTokenSource.erc20
+    assert order_creation.buyTokenBalance is BuyTokenDestination.erc20
+    assert order_creation.signingScheme is SigningScheme.eip712


### PR DESCRIPTION
## Problem

Every order-book serialization (`model_dump_json(by_alias=True)`, used by `serialize_model` in `common/api/api_base.py` on the `post_quote`/`post_order` paths) emitted an aggregated `UserWarning` full of `PydanticSerializationUnexpectedValue` entries for `'erc20'`, `'verified'`, and `'eip712'`.

Root cause: the datamodel-codegen-generated models declare enum-typed optional fields with raw string defaults (e.g. `sellTokenBalance: Optional[SellTokenSource] = "erc20"` in `OrderParameters`, `OrderQuoteRequest`, `OrderCreation`), and pydantic v2 defaults to `validate_default=False`, so instances hold plain `str` where the serializer expects enum members.

## Fix

- `cowdao_cowpy/order_book/base.py`: add `"validate_default": True` to `model_config` on the hand-written `BaseModel` that all generated models inherit from. Defaults are now coerced to enum members at construction time; serialized JSON is unchanged (still `"erc20"`/`"verified"`/`"eip712"` on the wire). Putting the fix on the base class means it survives spec regeneration.
- `Makefile`: add `--set-default-enum-member` to the `orderbook_codegen` datamodel-codegen invocation so future regenerations emit enum-member defaults directly (belt and braces; models were not regenerated in this PR).

## Testing

New `tests/order_book/test_serialization_warnings.py` constructs `OrderQuoteRequest` (same inputs as `cow/swap.py`) and `OrderCreation` with defaults, asserts `model_dump_json(by_alias=True)` emits no `UserWarning`, that the wire JSON still contains the expected string values, and that field access returns enum members.

Full suite: `pytest tests/ -q --deselect tests/e2e/test_upload_app_data.py` → **129 passed, 6 skipped, 24 warnings** (baseline: 127 passed, 25 warnings; the dropped warning is the pydantic serialization one). The deselected test fails on `main` with a live HTTP 429 (pre-existing, unrelated).

Fixes #71

*This PR was AI-implemented during a triage session.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> **Stacked on #84** (chain additions + openapi spec refresh — required for CI to pass on any branch). This PR's diff contains only its own commits. Merge #84 first; GitHub retargets this PR to `main` automatically.
