### PR TITLE
feat: HTTP client hardening — client injection, working retries, bearer token + partner API key auth

### DIFF
--- a/cowdao_cowpy/common/api/api_base.py
+++ b/cowdao_cowpy/common/api/api_base.py
@@ -63,8 +63,9 @@ class APIConfig(ABC):
     def api_key(self) -> Optional[str]:
         return self.context.get("api_key")
 
-    def get_base_url(self) -> str:
-        if self.api_key:
+    def get_base_url(self, api_key: Optional[str] = None) -> str:
+        effective_api_key = api_key if api_key is not None else self.api_key
+        if effective_api_key:
             partner_base_url = self.partner_config_map.get(self.chain_id)
             if partner_base_url:
                 return partner_base_url
@@ -184,6 +185,14 @@ class ApiBase:
             or self._client.is_closed
             or self._client_loop is not loop
         ):
+            if self._client is not None and not self._client.is_closed:
+                # The old client is bound to another loop, so it cannot be
+                # closed here. Close it on its own loop if that loop is still
+                # alive; with asyncio.run()-per-call the old loop is already
+                # closed and its transports were torn down with it.
+                old_client, old_loop = self._client, self._client_loop
+                if old_loop is not None and not old_loop.is_closed():
+                    asyncio.run_coroutine_threadsafe(old_client.aclose(), old_loop)
             self._client = httpx.AsyncClient()
             self._client_loop = loop
         return self._client
@@ -263,6 +272,9 @@ class ApiBase:
         """
         context_override = kwargs.get("context_override", {})
         url_override = None
+        # A request-scoped api_key must also affect URL routing (partner
+        # gateway), not just the X-API-Key header.
+        api_key_override = context_override.get("api_key")
 
         # Handle environment override
         if "env" in context_override:
@@ -270,13 +282,13 @@ class ApiBase:
             try:
                 # Use the config's with_env method to get a config for the desired environment
                 temp_config = self.config.with_env(env)
-                url_override = temp_config.get_base_url() + path
+                url_override = temp_config.get_base_url(api_key=api_key_override) + path
             except Exception as e:
                 # Log the error but continue with the default URL
                 print(f"Error switching environment: {e}")
 
         # Use the overridden URL or the default one
-        url = url_override or self.config.get_base_url() + path
+        url = url_override or self.config.get_base_url(api_key=api_key_override) + path
 
         kwargs = {k: v for k, v in kwargs.items() if k != "context_override"}
 

--- a/cowdao_cowpy/common/api/api_base.py
+++ b/cowdao_cowpy/common/api/api_base.py
@@ -1,12 +1,19 @@
 from abc import ABC
+import asyncio
+import importlib.metadata
 import json
 from typing import Any, Dict, List, Literal, Optional, Type, TypeVar, Union, get_args
 
 import httpx
 
-from cowdao_cowpy.common.api.decorators import rate_limitted, with_backoff
+from cowdao_cowpy.common.api.decorators import (
+    RETRYABLE_STATUS_CODES,
+    rate_limitted,
+    with_backoff,
+)
 from cowdao_cowpy.common.api.errors import (
     ApiResponseError,
+    BaseApiError,
     NetworkError,
     SerializationError,
     UnexpectedResponseError,
@@ -20,19 +27,47 @@ Envs = Literal["prod", "staging"]
 T = TypeVar("T")
 Context = dict[str, Any]
 
+try:
+    _VERSION = importlib.metadata.version("cowdao-cowpy")
+except importlib.metadata.PackageNotFoundError:
+    _VERSION = "development"
+
+USER_AGENT = f"cowdao-cowpy/{_VERSION}"
+
 
 class APIConfig(ABC):
     """Base class for API configuration with common functionality."""
 
-    config_map = {}
+    config_map: Dict[SupportedChainId, str] = {}
+    partner_config_map: Dict[SupportedChainId, str] = {}
 
     def __init__(
-        self, chain_id: SupportedChainId, base_context: Optional[Context] = None
+        self,
+        chain_id: SupportedChainId,
+        base_context: Optional[Context] = None,
+        bearer_token: Optional[str] = None,
+        api_key: Optional[str] = None,
     ):
         self.chain_id = chain_id
-        self.context = base_context or {}
+        self.context = dict(base_context) if base_context else {}
+        if bearer_token is not None:
+            self.context["bearer_token"] = bearer_token
+        if api_key is not None:
+            self.context["api_key"] = api_key
+
+    @property
+    def bearer_token(self) -> Optional[str]:
+        return self.context.get("bearer_token")
+
+    @property
+    def api_key(self) -> Optional[str]:
+        return self.context.get("api_key")
 
     def get_base_url(self) -> str:
+        if self.api_key:
+            partner_base_url = self.partner_config_map.get(self.chain_id)
+            if partner_base_url:
+                return partner_base_url
         base_url = self.config_map.get(
             self.chain_id,
         )
@@ -61,14 +96,24 @@ class APIConfig(ABC):
 
 
 class RequestStrategy:
-    async def make_request(self, client, url, method, **request_kwargs):
-        headers = {
+    async def make_request(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        method: str,
+        headers: Optional[Dict[str, str]] = None,
+        **request_kwargs,
+    ):
+        merged_headers = {
             "accept": "application/json",
             "content-type": "application/json",
+            "user-agent": USER_AGENT,
         }
+        if headers:
+            merged_headers.update({k.lower(): v for k, v in headers.items()})
 
         return await client.request(
-            url=url, headers=headers, method=method, **request_kwargs
+            url=url, headers=merged_headers, method=method, **request_kwargs
         )
 
 
@@ -99,22 +144,64 @@ class JsonResponseAdapter(ResponseAdapter):
             raise SerializationError(
                 f"Failed to decode JSON response: {str(e)}", response.text
             )
-        except httpx.HTTPStatusError as e:
-            raise ApiResponseError(
-                f"HTTP error {e.response.status_code}: {e.response.text}",
-                str(e.response.status_code),
-                e.response,
-            )
+
+
+def _extract_error_type(response: httpx.Response) -> str:
+    """Pull the orderbook errorType out of an error response body when available."""
+    try:
+        body = response.json()
+        if isinstance(body, dict) and "errorType" in body:
+            return str(body["errorType"])
+    except Exception:
+        pass
+    return str(response.status_code)
 
 
 class ApiBase:
-    def __init__(self, config: APIConfig):
+    def __init__(self, config: APIConfig, client: Optional[httpx.AsyncClient] = None):
         self.config = config
         self.request_strategy = RequestStrategy()
         self.response_adapter = JsonResponseAdapter()
         self.request_builder = RequestBuilder(
             self.request_strategy, self.response_adapter
         )
+        self._injected_client = client
+        self._client: Optional[httpx.AsyncClient] = None
+        self._client_loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Return the HTTP client to use, creating (and reusing) one if none was injected.
+
+        A lazily created client is bound to the running event loop; if the loop
+        changes (e.g. successive asyncio.run() calls), a fresh client is created.
+        """
+        if self._injected_client is not None:
+            return self._injected_client
+
+        loop = asyncio.get_running_loop()
+        if (
+            self._client is None
+            or self._client.is_closed
+            or self._client_loop is not loop
+        ):
+            self._client = httpx.AsyncClient()
+            self._client_loop = loop
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the lazily created HTTP client. Injected clients are managed by the caller."""
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+
+    def _build_auth_headers(self, context_override: Context) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        bearer_token = context_override.get("bearer_token", self.config.bearer_token)
+        api_key = context_override.get("api_key", self.config.api_key)
+        if bearer_token:
+            headers["Authorization"] = f"Bearer {bearer_token}"
+        if api_key:
+            headers["X-API-Key"] = api_key
+        return headers
 
     @staticmethod
     def serialize_model(data: Union[BaseModel, Dict[str, Any]]) -> Dict[str, Any]:
@@ -167,6 +254,8 @@ class ApiBase:
                 - context_override: Dict with request-specific configuration:
                     - env: Override the environment for this request ("prod", "staging")
                     - backoff_opts: Custom backoff options
+                    - bearer_token: Request-specific Authorization bearer token
+                    - api_key: Request-specific X-API-Key header
                     - Any other httpx client parameters
 
         Returns:
@@ -191,36 +280,43 @@ class ApiBase:
 
         kwargs = {k: v for k, v in kwargs.items() if k != "context_override"}
 
+        headers = {
+            **self._build_auth_headers(context_override),
+            **(kwargs.pop("headers", None) or {}),
+        }
+        if headers:
+            kwargs["headers"] = headers
+
         if "json" in kwargs:
             kwargs["json"] = self.serialize_model(kwargs["json"])
 
         try:
-            async with httpx.AsyncClient() as client:
-                data = await self.request_builder.execute(client, url, method, **kwargs)
-                if isinstance(data, dict) and "errorType" in data:
-                    raise ApiResponseError(
-                        f"API returned an error: {data.get('description', 'No description')}",
-                        data["errorType"],
-                        data,
-                    )
-
-                return (
-                    self.deserialize_model(data, response_model)
-                    if response_model
-                    else data
+            client = self._get_client()
+            data = await self.request_builder.execute(client, url, method, **kwargs)
+            if isinstance(data, dict) and "errorType" in data:
+                raise ApiResponseError(
+                    f"API returned an error: {data.get('description', 'No description')}",
+                    data["errorType"],
+                    data,
                 )
 
-        except httpx.NetworkError as e:
-            raise NetworkError(f"Network error occurred: {str(e)}")
+            return (
+                self.deserialize_model(data, response_model) if response_model else data
+            )
+
+        except httpx.TransportError as e:
+            raise NetworkError(f"Network error occurred: {str(e)}") from e
         except httpx.HTTPStatusError as e:
-            if e.response.status_code in (429, 500):
-                raise e
+            if e.response.status_code in RETRYABLE_STATUS_CODES:
+                raise
             raise ApiResponseError(
                 f"HTTP error {e.response.status_code}: {e.response.text}",
-                str(e.response.status_code),
+                _extract_error_type(e.response),
                 e.response,
-            )
+            ) from e
         except json.JSONDecodeError as e:
             raise SerializationError(f"Failed to decode JSON response: {str(e)}")
+        except BaseApiError:
+            raise
         except Exception as e:
             raise UnexpectedResponseError(f"An unexpected error occurred: {str(e)}")

--- a/cowdao_cowpy/common/api/decorators.py
+++ b/cowdao_cowpy/common/api/decorators.py
@@ -2,13 +2,29 @@ import backoff
 import httpx
 from aiolimiter import AsyncLimiter
 
+from cowdao_cowpy.common.api.errors import NetworkError, UnexpectedResponseError
+
 DEFAULT_LIMITER_OPTIONS = {"rate": 5, "per": 1.0}
 
 DEFAULT_BACKOFF_OPTIONS = {
     "max_tries": 10,
     "max_time": None,
     "jitter": None,
+    # Forwarded to backoff.expo: caps each wait so total backoff stays bounded.
+    "max_value": 8,
 }
+
+# HTTP statuses that are worth retrying, mirroring the TS SDK behavior.
+RETRYABLE_STATUS_CODES = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+RETRYABLE_EXCEPTIONS = (httpx.TransportError, httpx.HTTPStatusError, NetworkError)
+
+
+def is_retryable(exception: Exception) -> bool:
+    """Return True when the exception represents a transient failure worth retrying."""
+    if isinstance(exception, httpx.HTTPStatusError):
+        return exception.response.status_code in RETRYABLE_STATUS_CODES
+    return isinstance(exception, (httpx.TransportError, NetworkError))
 
 
 def dig(self, *keys):
@@ -32,13 +48,24 @@ def with_backoff():
 
             @backoff.on_exception(
                 backoff.expo,
-                (httpx.NetworkError, httpx.HTTPStatusError),
+                RETRYABLE_EXCEPTIONS,
+                giveup=lambda e: not is_retryable(e),
                 **internal_backoff_opts,
             )
             async def closure():
                 return await func(*args, **kwargs)
 
-            return await closure()
+            try:
+                return await closure()
+            except httpx.HTTPStatusError as e:
+                if is_retryable(e):
+                    # Retries exhausted on a retryable status: surface the same
+                    # typed error callers historically received.
+                    raise UnexpectedResponseError(
+                        f"HTTP error {e.response.status_code} persisted after retries: {e.response.text}",
+                        e.response,
+                    ) from e
+                raise
 
         return wrapper
 

--- a/cowdao_cowpy/common/api/decorators.py
+++ b/cowdao_cowpy/common/api/decorators.py
@@ -41,10 +41,9 @@ def with_backoff():
         async def wrapper(*args, **kwargs):
             backoff_opts = dig(kwargs, "context_override", "backoff_opts")
 
-            if backoff_opts is None:
-                internal_backoff_opts = DEFAULT_BACKOFF_OPTIONS
-            else:
-                internal_backoff_opts = backoff_opts
+            # Merge so partial overrides (e.g. {"max_tries": 3}) keep the
+            # remaining defaults, notably the max_value wait cap.
+            internal_backoff_opts = {**DEFAULT_BACKOFF_OPTIONS, **(backoff_opts or {})}
 
             @backoff.on_exception(
                 backoff.expo,

--- a/cowdao_cowpy/common/api/errors.py
+++ b/cowdao_cowpy/common/api/errors.py
@@ -18,8 +18,19 @@ class SerializationError(BaseApiError):
     pass
 
 
-class ApiResponseError(BaseApiError):
-    """Raised when the API returns an error response."""
+class UnexpectedResponseError(BaseApiError):
+    """Raised when the API returns an unexpected response."""
+
+    pass
+
+
+class ApiResponseError(UnexpectedResponseError):
+    """Raised when the API returns an error response.
+
+    Subclasses UnexpectedResponseError for backwards compatibility: callers
+    that caught UnexpectedResponseError keep working now that API errors
+    propagate with their original errorType instead of being rewrapped.
+    """
 
     def __init__(
         self, message: str, error_type: str, response: Dict[str, Any] | Response
@@ -30,11 +41,5 @@ class ApiResponseError(BaseApiError):
 
 class NetworkError(BaseApiError):
     """Raised when there's a network-related error."""
-
-    pass
-
-
-class UnexpectedResponseError(BaseApiError):
-    """Raised when the API returns an unexpected response."""
 
     pass

--- a/cowdao_cowpy/common/config.py
+++ b/cowdao_cowpy/common/config.py
@@ -31,6 +31,8 @@ class ApiContext:
     env: CowEnv
     base_urls: Optional[ApiBaseUrls] = None
     max_tries: Optional[int] = 5
+    bearer_token: Optional[str] = None
+    api_key: Optional[str] = None
 
 
 # Define the list of available environments.

--- a/cowdao_cowpy/order_book/api.py
+++ b/cowdao_cowpy/order_book/api.py
@@ -1,4 +1,7 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
 from cowdao_cowpy.common.api.api_base import ApiBase, Context
 from cowdao_cowpy.common.api.errors import UnexpectedResponseError
 from cowdao_cowpy.common.config import SupportedChainId, ENVS_LIST
@@ -32,8 +35,9 @@ class OrderBookApi(ApiBase):
     def __init__(
         self,
         config=OrderBookAPIConfigFactory.get_config("prod", SupportedChainId.MAINNET),
+        client: Optional[httpx.AsyncClient] = None,
     ):
-        super().__init__(config)
+        super().__init__(config, client=client)
 
     async def get_version(self, context_override: Context = {}) -> str:
         return await self._fetch("/api/v1/version", context_override=context_override)

--- a/cowdao_cowpy/order_book/config.py
+++ b/cowdao_cowpy/order_book/config.py
@@ -1,6 +1,6 @@
-from typing import Dict, Literal, Type
+from typing import Dict, Literal, Optional, Type
 
-from cowdao_cowpy.common.api.api_base import APIConfig
+from cowdao_cowpy.common.api.api_base import APIConfig, Context
 from cowdao_cowpy.common.config import SupportedChainId
 
 # Define the Envs type
@@ -22,15 +22,36 @@ class ProdAPIConfig(APIConfig):
         SupportedChainId.INK: "https://api.cow.fi/ink",
     }
 
-    def __init__(self, chain_id: SupportedChainId, base_context=None):
-        super().__init__(chain_id, base_context)
+    # Partner gateway, used instead of config_map when an api_key is configured.
+    partner_config_map = {
+        SupportedChainId.MAINNET: "https://partners.cow.fi/mainnet",
+        SupportedChainId.SEPOLIA: "https://partners.cow.fi/sepolia",
+        SupportedChainId.GNOSIS_CHAIN: "https://partners.cow.fi/xdai",
+        SupportedChainId.ARBITRUM_ONE: "https://partners.cow.fi/arbitrum_one",
+        SupportedChainId.BASE: "https://partners.cow.fi/base",
+        SupportedChainId.POLYGON: "https://partners.cow.fi/polygon",
+        SupportedChainId.AVALANCHE: "https://partners.cow.fi/avalanche",
+        SupportedChainId.LENS: "https://partners.cow.fi/lens",
+        SupportedChainId.BNB: "https://partners.cow.fi/bnb",
+    }
+
+    def __init__(
+        self,
+        chain_id: SupportedChainId,
+        base_context: Optional[Context] = None,
+        bearer_token: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
+        super().__init__(chain_id, base_context, bearer_token, api_key)
         self.env = "prod"  # Store the environment
 
     def with_env(self, env: Envs) -> APIConfig:
         """Switch to a different environment configuration."""
         if env == self.env:
             return self
-        return OrderBookAPIConfigFactory.get_config(env, self.chain_id)
+        return OrderBookAPIConfigFactory.get_config(
+            env, self.chain_id, base_context=self.context
+        )
 
 
 class StagingAPIConfig(APIConfig):
@@ -48,15 +69,36 @@ class StagingAPIConfig(APIConfig):
         SupportedChainId.INK: "https://barn.api.cow.fi/ink",
     }
 
-    def __init__(self, chain_id: SupportedChainId, base_context=None):
-        super().__init__(chain_id, base_context)
+    # Partner gateway, used instead of config_map when an api_key is configured.
+    partner_config_map = {
+        SupportedChainId.MAINNET: "https://partners.barn.cow.fi/mainnet",
+        SupportedChainId.SEPOLIA: "https://partners.barn.cow.fi/sepolia",
+        SupportedChainId.GNOSIS_CHAIN: "https://partners.barn.cow.fi/xdai",
+        SupportedChainId.ARBITRUM_ONE: "https://partners.barn.cow.fi/arbitrum_one",
+        SupportedChainId.BASE: "https://partners.barn.cow.fi/base",
+        SupportedChainId.POLYGON: "https://partners.barn.cow.fi/polygon",
+        SupportedChainId.AVALANCHE: "https://partners.barn.cow.fi/avalanche",
+        SupportedChainId.LENS: "https://partners.barn.cow.fi/lens",
+        SupportedChainId.BNB: "https://partners.barn.cow.fi/bnb",
+    }
+
+    def __init__(
+        self,
+        chain_id: SupportedChainId,
+        base_context: Optional[Context] = None,
+        bearer_token: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
+        super().__init__(chain_id, base_context, bearer_token, api_key)
         self.env = "staging"  # Store the environment
 
     def with_env(self, env: Envs) -> APIConfig:
         """Switch to a different environment configuration."""
         if env == self.env:
             return self
-        return OrderBookAPIConfigFactory.get_config(env, self.chain_id)
+        return OrderBookAPIConfigFactory.get_config(
+            env, self.chain_id, base_context=self.context
+        )
 
 
 class OrderBookAPIConfigFactory:
@@ -66,11 +108,22 @@ class OrderBookAPIConfigFactory:
     }
 
     @staticmethod
-    def get_config(env: Envs, chain_id: SupportedChainId) -> APIConfig:
+    def get_config(
+        env: Envs,
+        chain_id: SupportedChainId,
+        base_context: Optional[Context] = None,
+        bearer_token: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ) -> APIConfig:
         """Get a config instance for the specified environment and chain."""
         config_class = OrderBookAPIConfigFactory.config_classes.get(env)
 
         if config_class:
-            return config_class(chain_id)
+            return config_class(
+                chain_id,
+                base_context,
+                bearer_token=bearer_token,
+                api_key=api_key,
+            )
         else:
             raise ValueError(f"Unknown environment: {env}")

--- a/cowdao_cowpy/order_book/config.py
+++ b/cowdao_cowpy/order_book/config.py
@@ -31,8 +31,10 @@ class ProdAPIConfig(APIConfig):
         SupportedChainId.BASE: "https://partners.cow.fi/base",
         SupportedChainId.POLYGON: "https://partners.cow.fi/polygon",
         SupportedChainId.AVALANCHE: "https://partners.cow.fi/avalanche",
-        SupportedChainId.LENS: "https://partners.cow.fi/lens",
         SupportedChainId.BNB: "https://partners.cow.fi/bnb",
+        SupportedChainId.LINEA: "https://partners.cow.fi/linea",
+        SupportedChainId.PLASMA: "https://partners.cow.fi/plasma",
+        SupportedChainId.INK: "https://partners.cow.fi/ink",
     }
 
     def __init__(
@@ -78,8 +80,10 @@ class StagingAPIConfig(APIConfig):
         SupportedChainId.BASE: "https://partners.barn.cow.fi/base",
         SupportedChainId.POLYGON: "https://partners.barn.cow.fi/polygon",
         SupportedChainId.AVALANCHE: "https://partners.barn.cow.fi/avalanche",
-        SupportedChainId.LENS: "https://partners.barn.cow.fi/lens",
         SupportedChainId.BNB: "https://partners.barn.cow.fi/bnb",
+        SupportedChainId.LINEA: "https://partners.barn.cow.fi/linea",
+        SupportedChainId.PLASMA: "https://partners.barn.cow.fi/plasma",
+        SupportedChainId.INK: "https://partners.barn.cow.fi/ink",
     }
 
     def __init__(

--- a/tests/common/api/test_api_base.py
+++ b/tests/common/api/test_api_base.py
@@ -19,7 +19,7 @@ def sut():
         def __init__(self):
             super().__init__(SupportedChainId.SEPOLIA, None)
 
-        def get_base_url(self):
+        def get_base_url(self, api_key=None):
             return "http://localhost"
 
     class MyAPI(ApiBase):

--- a/tests/common/api/test_api_base.py
+++ b/tests/common/api/test_api_base.py
@@ -5,6 +5,7 @@ import pytest
 
 from cowdao_cowpy.common.api.api_base import ApiBase, APIConfig
 from cowdao_cowpy.common.api.decorators import DEFAULT_BACKOFF_OPTIONS
+from cowdao_cowpy.common.api.errors import UnexpectedResponseError
 from cowdao_cowpy.common.config import SupportedChainId
 from httpx import Request
 
@@ -106,7 +107,7 @@ async def test_does_not_reattempt_after_max_failures(sut, mock_http_status_error
     with patch(
         "httpx.AsyncClient.request", side_effect=[mock_http_status_error] * 3
     ) as mock_call:
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(UnexpectedResponseError):
             await sut.get_version(context_override={"backoff_opts": {"max_tries": 3}})
 
         assert mock_call.call_count == 3
@@ -125,7 +126,7 @@ async def test_backoff_uses_function_options_instead_of_default(
         "httpx.AsyncClient.request",
         side_effect=[mock_http_status_error] * max_tries,
     ) as mock_call:
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(UnexpectedResponseError):
             await sut.get_version(
                 context_override={"backoff_opts": {"max_tries": max_tries}}
             )

--- a/tests/common/api/test_http_hardening.py
+++ b/tests/common/api/test_http_hardening.py
@@ -97,6 +97,35 @@ async def test_context_override_auth_headers(httpx_mock: HTTPXMock):
 
 
 @pytest.mark.asyncio
+async def test_context_override_api_key_routes_to_partner_gateway(
+    httpx_mock: HTTPXMock,
+):
+    httpx_mock.add_response(url=f"{PARTNER_BASE_URL}/api/v1/version", json=OK_RESPONSE)
+
+    await make_sut().get_version(context_override={"api_key": "override-key"})
+
+    request = httpx_mock.get_requests()[0]
+    assert request.headers["x-api-key"] == "override-key"
+    assert str(request.url) == f"{PARTNER_BASE_URL}/api/v1/version"
+
+
+@pytest.mark.asyncio
+async def test_partial_backoff_opts_merge_with_defaults(httpx_mock: HTTPXMock):
+    # A partial override must keep the remaining defaults rather than
+    # replacing them; with only max_tries given, retries must still happen
+    # (and the merged opts must not lose keys like max_value).
+    httpx_mock.add_response(status_code=429)
+    httpx_mock.add_response(json=OK_RESPONSE)
+
+    response = await make_sut().get_version(
+        context_override={"backoff_opts": {"max_tries": 2, "factor": 0.01}}
+    )
+
+    assert response == OK_RESPONSE
+    assert len(httpx_mock.get_requests()) == 2
+
+
+@pytest.mark.asyncio
 async def test_retries_429_then_succeeds(httpx_mock: HTTPXMock):
     httpx_mock.add_response(status_code=429)
     httpx_mock.add_response(json=OK_RESPONSE)
@@ -178,3 +207,26 @@ async def test_lazy_client_created_once_and_reused(httpx_mock: HTTPXMock):
 
     await sut.aclose()
     assert first_client.is_closed
+
+
+@pytest.mark.asyncio
+async def test_order_book_api_accepts_injected_client(httpx_mock: HTTPXMock):
+    from cowdao_cowpy.common.config import SupportedChainId
+    from cowdao_cowpy.order_book.api import OrderBookApi
+    from cowdao_cowpy.order_book.config import OrderBookAPIConfigFactory
+
+    httpx_mock.add_response(url="https://api.cow.fi/xdai/api/v1/version", json="1.0.0")
+
+    client = httpx.AsyncClient()
+    order_book = OrderBookApi(
+        config=OrderBookAPIConfigFactory.get_config(
+            "prod", SupportedChainId.GNOSIS_CHAIN
+        ),
+        client=client,
+    )
+
+    await order_book.get_version()
+
+    assert order_book._get_client() is client
+    assert not client.is_closed
+    await client.aclose()

--- a/tests/common/api/test_http_hardening.py
+++ b/tests/common/api/test_http_hardening.py
@@ -1,0 +1,180 @@
+from typing import Optional
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from cowdao_cowpy.common.api.api_base import USER_AGENT, ApiBase, APIConfig
+from cowdao_cowpy.common.api.errors import ApiResponseError
+from cowdao_cowpy.common.config import SupportedChainId
+
+OK_RESPONSE = {"ok": True}
+
+BASE_URL = "http://localhost"
+PARTNER_BASE_URL = "http://partner.localhost"
+
+FAST_BACKOFF = {"backoff_opts": {"max_tries": 3, "jitter": None, "factor": 0.01}}
+
+
+def make_sut(
+    bearer_token: Optional[str] = None,
+    api_key: Optional[str] = None,
+    client: Optional[httpx.AsyncClient] = None,
+):
+    class MyConfig(APIConfig):
+        config_map = {SupportedChainId.SEPOLIA: BASE_URL}
+        partner_config_map = {SupportedChainId.SEPOLIA: PARTNER_BASE_URL}
+
+        def __init__(self):
+            super().__init__(
+                SupportedChainId.SEPOLIA,
+                None,
+                bearer_token=bearer_token,
+                api_key=api_key,
+            )
+
+    class MyAPI(ApiBase):
+        async def get_version(self, context_override={}):
+            return await self._fetch(
+                path="/api/v1/version", context_override=context_override
+            )
+
+    return MyAPI(config=MyConfig(), client=client)
+
+
+@pytest.mark.asyncio
+async def test_sends_user_agent_and_default_headers(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(json=OK_RESPONSE)
+
+    await make_sut().get_version()
+
+    request = httpx_mock.get_requests()[0]
+    assert request.headers["user-agent"] == USER_AGENT
+    assert request.headers["accept"] == "application/json"
+    assert request.headers["content-type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_no_auth_headers_by_default(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(json=OK_RESPONSE)
+
+    await make_sut().get_version()
+
+    request = httpx_mock.get_requests()[0]
+    assert "authorization" not in request.headers
+    assert "x-api-key" not in request.headers
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_sets_authorization_header(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(json=OK_RESPONSE)
+
+    await make_sut(bearer_token="my-token").get_version()
+
+    request = httpx_mock.get_requests()[0]
+    assert request.headers["authorization"] == "Bearer my-token"
+
+
+@pytest.mark.asyncio
+async def test_api_key_sets_header_and_partner_gateway_url(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=f"{PARTNER_BASE_URL}/api/v1/version", json=OK_RESPONSE)
+
+    await make_sut(api_key="my-key").get_version()
+
+    request = httpx_mock.get_requests()[0]
+    assert request.headers["x-api-key"] == "my-key"
+    assert str(request.url) == f"{PARTNER_BASE_URL}/api/v1/version"
+
+
+@pytest.mark.asyncio
+async def test_context_override_auth_headers(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(json=OK_RESPONSE)
+
+    await make_sut().get_version(context_override={"bearer_token": "override-token"})
+
+    request = httpx_mock.get_requests()[0]
+    assert request.headers["authorization"] == "Bearer override-token"
+
+
+@pytest.mark.asyncio
+async def test_retries_429_then_succeeds(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(status_code=429)
+    httpx_mock.add_response(json=OK_RESPONSE)
+
+    response = await make_sut().get_version(context_override=FAST_BACKOFF)
+
+    assert response == OK_RESPONSE
+    assert len(httpx_mock.get_requests()) == 2
+
+
+@pytest.mark.asyncio
+async def test_403_fails_immediately_without_retry(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(status_code=403, text="blocked")
+
+    with pytest.raises(ApiResponseError) as exc_info:
+        await make_sut().get_version(context_override=FAST_BACKOFF)
+
+    assert exc_info.value.error_type == "403"
+    assert len(httpx_mock.get_requests()) == 1
+
+
+@pytest.mark.asyncio
+async def test_error_type_preserved_from_error_response_body(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        status_code=400,
+        json={"errorType": "InsufficientBalance", "description": "not enough funds"},
+    )
+
+    with pytest.raises(ApiResponseError) as exc_info:
+        await make_sut().get_version(context_override=FAST_BACKOFF)
+
+    assert exc_info.value.error_type == "InsufficientBalance"
+    assert len(httpx_mock.get_requests()) == 1
+
+
+@pytest.mark.asyncio
+async def test_error_type_in_ok_body_not_rewrapped(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        json={"errorType": "NoLiquidity", "description": "no liquidity"}
+    )
+
+    with pytest.raises(ApiResponseError) as exc_info:
+        await make_sut().get_version()
+
+    assert exc_info.value.error_type == "NoLiquidity"
+
+
+@pytest.mark.asyncio
+async def test_injected_client_is_reused_and_left_open(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(json=OK_RESPONSE)
+    httpx_mock.add_response(json=OK_RESPONSE)
+
+    client = httpx.AsyncClient()
+    sut = make_sut(client=client)
+
+    await sut.get_version()
+    await sut.get_version()
+
+    assert sut._get_client() is client
+    assert not client.is_closed
+    assert len(httpx_mock.get_requests()) == 2
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_lazy_client_created_once_and_reused(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(json=OK_RESPONSE)
+    httpx_mock.add_response(json=OK_RESPONSE)
+
+    sut = make_sut()
+
+    await sut.get_version()
+    first_client = sut._client
+    await sut.get_version()
+
+    assert first_client is not None
+    assert sut._client is first_client
+    assert not first_client.is_closed
+
+    await sut.aclose()
+    assert first_client.is_closed

--- a/tests/order_book/test_api.py
+++ b/tests/order_book/test_api.py
@@ -24,6 +24,35 @@ def order_book_api():
     return OrderBookApi(config=config)
 
 
+def test_default_base_url_without_api_key():
+    config = OrderBookAPIConfigFactory.get_config("prod", SupportedChainId.MAINNET)
+    assert config.get_base_url() == "https://api.cow.fi/mainnet"
+
+
+def test_partner_gateway_base_url_when_api_key_set():
+    config = OrderBookAPIConfigFactory.get_config(
+        "prod", SupportedChainId.MAINNET, api_key="my-key"
+    )
+    assert config.get_base_url() == "https://partners.cow.fi/mainnet"
+
+
+def test_partner_gateway_base_url_staging():
+    config = OrderBookAPIConfigFactory.get_config(
+        "staging", SupportedChainId.MAINNET, api_key="my-key"
+    )
+    assert config.get_base_url() == "https://partners.barn.cow.fi/mainnet"
+
+
+def test_with_env_preserves_auth_context():
+    config = OrderBookAPIConfigFactory.get_config(
+        "prod", SupportedChainId.MAINNET, api_key="my-key", bearer_token="my-token"
+    )
+    staging = config.with_env("staging")
+    assert staging.api_key == "my-key"
+    assert staging.bearer_token == "my-token"
+    assert staging.get_base_url() == "https://partners.barn.cow.fi/mainnet"
+
+
 @pytest.mark.asyncio
 async def test_get_version(order_book_api):
     expected_version = "1.0.0"


### PR DESCRIPTION
## Problem

Part of #78 (mitigations B + C). Prerequisite for #77.

1. **No escape hatch from CloudFront WAF/rate-limit blocking.** `ApiBase._fetch` built a throwaway `httpx.AsyncClient()` per request with hardcoded headers and the default `python-httpx` User-Agent, so users could not mount a custom transport (curl_cffi, custom SSL context) or reuse connections. Live-verified during triage: CloudFront 429'd httpx traffic while `requests` from the same host got 200 seconds apart.
2. **The retry logic was dead.** `with_backoff` only retried `httpx.NetworkError`/`HTTPStatusError`, but neither ever escaped `_fetch`: `HTTPStatusError` was converted to `ApiResponseError` inside `adapt_response`, and the catch-all rewrapped everything into `UnexpectedResponseError`. Nothing was ever retried, and the orderbook `errorType` (e.g. `InsufficientBalance`) never reached callers.
3. **No auth support**, unlike the TS SDK (bearer token: cowprotocol/cow-sdk#825, partner api key: cowprotocol/cow-sdk#809).

## Fix

- **Client injection + reuse**: `OrderBookApi(config, client=...)` / `ApiBase(config, client=...)` accept a long-lived `httpx.AsyncClient`; otherwise one shared client is lazily created per instance, bound to the running event loop (recreated if the loop changes — a superseded client is closed on its own loop when that loop is still alive — so repeated `asyncio.run()` callers keep working). New `ApiBase.aclose()` closes the owned client; injected clients stay caller-managed.
- **Headers**: every request sends `User-Agent: cowdao-cowpy/{version}` (read via `importlib.metadata`, no circular import) and merges per-call headers. A stable UA also gives CoW infra something to allowlist.
- **Auth**: `bearer_token` → `Authorization: Bearer <token>`, `api_key` → `X-API-Key: <key>`. Configurable on `APIConfig` subclasses, `OrderBookAPIConfigFactory.get_config(...)`, or per-call via `context_override` (a request-scoped `api_key` also switches URL routing). When `api_key` is set, order book requests route through the partner gateway (`https://partners.cow.fi/{network}`, staging `https://partners.barn.cow.fi/{network}`). `with_env()` preserves auth context. Behavior is bit-identical when no auth is configured.
- **Working retries**: transport errors and HTTP `408/425/429/500/502/503/504` are retried with exponential backoff (honors `max_tries`; waits capped via `max_value=8`; partial `backoff_opts` overrides merge with defaults); 403 and other 4xx fail immediately. Exhausted retries surface as `UnexpectedResponseError` (the same type callers historically received), keeping existing fallbacks intact.
- **Typed errors propagate**: `ApiResponseError` (carrying the orderbook `errorType`, extracted from the error body) is no longer rewrapped by the catch-all. It subclasses `UnexpectedResponseError` so existing `except UnexpectedResponseError` call sites keep working.

## Testing

New `tests/common/api/test_http_hardening.py` (pytest-httpx): UA header; default no-auth headers; bearer/api-key headers; partner gateway URL (config-level and request-scoped); 429→200 retry succeeds; 403 fails immediately with no retry; partial `backoff_opts` merge; `errorType` preserved end-to-end; injected client reused and left open (including via the public `OrderBookApi` constructor); lazy client created once and closed by `aclose()`. Plus order book config tests for gateway URL selection and `with_env` auth preservation.

Full suite: `pytest tests/ -q --deselect tests/e2e/test_upload_app_data.py` → **145 passed, 6 skipped** (baseline: 127 passed; 18 new tests). The deselected test is the pre-existing live-429 e2e failure on `main`.

Reviewer notes (deliberate decisions):
- Working retries now re-send non-idempotent POSTs on 5xx — mirrors the TS SDK; can be restricted in a follow-up if duplicate-submission risk is a concern.
- `SerializationError` now escapes as itself instead of being rewrapped (same family as the `ApiResponseError` change).

Part of #78. Prerequisite for #77.

*This PR was AI-implemented during a triage session.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> **Stacked on #84** (chain additions + openapi spec refresh — required for CI to pass on any branch). This PR's diff contains only its own commits. Merge #84 first; GitHub retargets this PR to `main` automatically.
