### PR TITLE
fix: get_order_competition_status used the wrong response model and malformed URL

### DIFF
--- a/cowdao_cowpy/order_book/api.py
+++ b/cowdao_cowpy/order_book/api.py
@@ -8,6 +8,7 @@ from cowdao_cowpy.order_book.generated.model import (
     Address,
     AppDataHash,
     AppDataObject,
+    CompetitionOrderStatus,
     NativePriceResponse,
     Order,
     OrderCreation,
@@ -99,11 +100,11 @@ class OrderBookApi(ApiBase):
 
     async def get_order_competition_status(
         self, order_uid: UID, context_override: Context = {}
-    ) -> Order:
+    ) -> CompetitionOrderStatus:
         return await self._fetch(
-            path=f"/api/v1/orders/{order_uid}/status",
+            path=f"/api/v1/orders/{order_uid.root}/status",
             context_override=context_override,
-            response_model=Order,
+            response_model=CompetitionOrderStatus,
         )
 
     def get_order_link(self, order_uid: UID) -> str:

--- a/tests/order_book/test_api.py
+++ b/tests/order_book/test_api.py
@@ -1,12 +1,12 @@
 # test_order_book_api.py
-import json
 from unittest.mock import AsyncMock, Mock, patch
 import pytest
-from cowdao_cowpy.order_book.api import Order, OrderBookApi
+from cowdao_cowpy.order_book.api import OrderBookApi
 from cowdao_cowpy.order_book.config import OrderBookAPIConfigFactory
 from cowdao_cowpy.common.config import SupportedChainId
 from cowdao_cowpy.order_book.generated.model import (
     Address,
+    CompetitionOrderStatus,
     OrderQuoteRequest,
     OrderQuoteSide1,
     OrderQuoteSideKindSell,
@@ -14,6 +14,7 @@ from cowdao_cowpy.order_book.generated.model import (
     OrderQuoteResponse,
     Trade,
     OrderCreation,
+    Type as CompetitionStatusType,
     UID,
 )
 
@@ -148,43 +149,30 @@ async def test_post_order(order_book_api):
 
 @pytest.mark.asyncio
 async def test_order_status(order_book_api):
-    mock_uid = "mock_uid"
-    mock_order_creation = Order(
-        sellToken="0x",
-        buyToken="0x",
-        sellAmount="0",
-        buyAmount="0",
-        validTo=0,
-        feeAmount="0",
-        kind="buy",
-        partiallyFillable=True,
-        appData="0x",
-        signingScheme="eip712",
-        signature="0x",
-        receiver="0x",
-        sellTokenBalance="erc20",
-        buyTokenBalance="erc20",
-        quoteId=0,
-        appDataHash="0x",
-        from_="0x",  # type: ignore # pyright doesn't recognize `populate_by_name=True`.
-        creationDate="2023-01-01T00:00:00Z",
-        uid=UID(mock_uid),
-        owner="0x",
-        executedSellAmount="0",
-        status="open",
-        invalidated=False,
-        executedBuyAmount="0",
-        executedSellAmountBeforeFees="0",
-        executedFeeAmount="0",
-        settlementContract="0x",
-        class_="market",  # type: ignore
-    )
+    mock_uid = "0x" + "ab" * 56
+    mock_status = {
+        "type": "active",
+        "value": [
+            {"solver": "solver-a", "executedAmounts": None},
+            {
+                "solver": "solver-b",
+                "executedAmounts": {"sell": "1000", "buy": "2000"},
+            },
+        ],
+    }
     with patch("httpx.AsyncClient.request", new_callable=AsyncMock) as mock_request:
-        mock_request.return_value.text = json.loads(
-            mock_order_creation.model_dump_json()
+        mock_request.return_value = AsyncMock(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            json=Mock(return_value=mock_status),
         )
-        response = await order_book_api.get_order_competition_status(
-            mock_order_creation
-        )
+        response = await order_book_api.get_order_competition_status(UID(mock_uid))
         mock_request.assert_awaited_once()
-        assert response.uid.root == mock_uid
+        # The bare hex UID is interpolated into the URL, not the model repr.
+        requested_url = mock_request.call_args.kwargs["url"]
+        assert f"/api/v1/orders/{mock_uid}/status" in requested_url
+        assert "root=" not in requested_url
+        assert isinstance(response, CompetitionOrderStatus)
+        assert response.type == CompetitionStatusType.active
+        assert response.value is not None
+        assert response.value[1].solver == "solver-b"


### PR DESCRIPTION
## Problem

Found while triaging the order book client against the refreshed openapi spec: `OrderBookApi.get_order_competition_status` was broken in two independent ways.

1. **Wrong response model.** The method deserialized `GET /api/v1/orders/{uid}/status` into the `Order` model, but the spec defines `CompetitionOrderStatus` (`{type, value: [{solver, executedAmounts}]}`) for this endpoint. Any real API response failed pydantic validation, so the method could never return successfully against the live orderbook.
2. **Malformed URL.** It interpolated the `UID` root model directly into the path, producing `/api/v1/orders/root='0x…'/status` instead of the bare hex uid — the same bug class as the `put_app_data` URL fix in #79 (reported on Discord as URLs containing `root='…'`).

Both bugs were masked by the existing test, which passed an `Order` object where the uid belongs and mocked the response with that same Order's JSON — so the test validated a round-trip that can't happen against the real API.

## Fix

- Deserialize into `CompetitionOrderStatus` (now generated from the refreshed spec) and update the return type accordingly.
- Interpolate `order_uid.root` into the request path, matching `get_order_link` and the rest of the client.
- Rewrite `test_order_status`: passes a real `UID`, mocks a realistic competition-status payload (two solvers, one with executed amounts), and asserts the requested URL contains the bare hex uid with no `root=` fragment.

## Testing

Full suite: `pytest tests/ -q` → **131 passed, 7 skipped** (offline). Pyright and ruff clean.

> Breaking note for anyone who used this method: the return type changes from `Order` (which never validated in practice) to `CompetitionOrderStatus`. Given the method couldn't succeed against the live API, treating this as a fix rather than a breaking change seems fair.

---

> **Stacked on #84** (chain additions + openapi spec refresh — the `CompetitionOrderStatus` model comes from the refreshed spec). This PR's diff contains only its own commit. Merge #84 first; GitHub retargets this PR to `main` automatically.

*This PR was AI-implemented during a triage session.*
